### PR TITLE
Generate CSV with QUOTE_MINIMAL

### DIFF
--- a/clickhouse_mysql/writer/csvwriter.py
+++ b/clickhouse_mysql/writer/csvwriter.py
@@ -136,7 +136,7 @@ class CSVWriter(Writer):
             if self.dst_table is None:
                 self.dst_table = event.table
 
-            self.writer = csv.DictWriter(self.file, fieldnames=self.fieldnames, quoting=csv.QUOTE_ALL)
+            self.writer = csv.DictWriter(self.file, fieldnames=self.fieldnames, quoting=csv.QUOTE_MINIMAL)
             if not self.header_written:
                 self.writer.writeheader()
 


### PR DESCRIPTION
Use QUOTE_MINIMAL to avoid sending null values as `,"",` causing the ingestion to detect it as empty value instead of NULL one