### PR TITLE
Added ts to the binlog event to track the order in which events arrive

### DIFF
--- a/clickhouse_mysql/event/event.py
+++ b/clickhouse_mysql/event/event.py
@@ -5,7 +5,10 @@
 class Event(object):
 
     # main payload - one or multiple rows
-
+    
+    # Timestamp to know when the event arrive.
+    ts = None
+    
     # native mysql replication event
     # one of from pymysqlreplication.row_event import
     # contains rows internally

--- a/clickhouse_mysql/reader/mysqlreader.py
+++ b/clickhouse_mysql/reader/mysqlreader.py
@@ -13,6 +13,7 @@ from clickhouse_mysql.event.event import Event
 from clickhouse_mysql.tableprocessor import TableProcessor
 from clickhouse_mysql.util import Util
 
+from datetime import datetime
 
 class MySQLReader(Reader):
     """Read data from MySQL as replication ls"""
@@ -290,6 +291,7 @@ class MySQLReader(Reader):
 
                 # dispatch Event
                 event = Event()
+                event.ts = datetime.utcnow()
                 event.schema = mysql_event.schema
                 event.table = mysql_event.table
                 event.row = row['values']
@@ -326,6 +328,7 @@ class MySQLReader(Reader):
 
             # dispatch Event
             event = Event()
+            event.ts = datetime.utcnow()
             event.schema = mysql_event.schema
             event.table = mysql_event.table
             event.pymysqlreplication_event = mysql_event
@@ -365,6 +368,7 @@ class MySQLReader(Reader):
 
             # dispatch Event
             event = Event()
+            event.ts = datetime.utcnow()
             event.schema = mysql_event.schema
             event.table = mysql_event.table
             event.pymysqlreplication_event = mysql_event

--- a/clickhouse_mysql/writer/chwriter.py
+++ b/clickhouse_mysql/writer/chwriter.py
@@ -76,7 +76,7 @@ class CHWriter(Writer):
             for row in event_converted:
                 # These columns are added to identify the last change (tb_upd) and the kind of operation performed
                 # 0 - INSERT, 1 - UPDATE, 2 - DELETE
-                row['tb_upd'] = datetime.datetime.now()
+                row['tb_upd'] = event.ts.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
                 row['operation'] = 0
 
                 for key in row.keys():
@@ -84,9 +84,6 @@ class CHWriter(Writer):
                     if type(row[key]) == [Decimal, datetime.timedelta]:
                         row[key] = str(row[key])
 
-                # These columns are added to identify the last change (tb_upd) and when a row is deleted (1)
-                # row['tb_upd'] = datetime.datetime.now()
-                # row['operation'] = 0
                 rows.append(row)
 
         logging.debug('class:%s insert %d row(s)', __class__, len(rows))
@@ -162,7 +159,7 @@ class CHWriter(Writer):
             for row in event_converted:
                 # These columns are added to identify the last change (tb_upd) and the kind of operation performed
                 # 0 - INSERT, 1 - UPDATE, 2 - DELETE
-                row['tb_upd'] = datetime.datetime.now()
+                row['tb_upd'] = event.ts.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
                 row['operation'] = 2
 
                 for key in row.keys():
@@ -170,9 +167,6 @@ class CHWriter(Writer):
                     if type(row[key]) in [Decimal, datetime.timedelta]:
                         row[key] = str(row[key])
 
-                # These columns are added to identify the last change (tb_upd) and when a row is deleted (1)
-                # row['tb_upd'] = datetime.datetime.now()
-                # row['operation'] = 2
                 rows.append(row)
 
         logging.debug('class:%s delete %d row(s)', __class__, len(rows))
@@ -194,11 +188,6 @@ class CHWriter(Writer):
                                                                                        self.dst_table))
 
         # and DELETE converted rows
-
-        # These columns are added to identify the last change (tb_upd) and the kind of operation performed
-        # 0 - INSERT, 1 - UPDATE, 2 - DELETE
-        rows[0]['tb_upd'] = datetime.datetime.now()
-        rows[0]['operation'] = 2
 
         sql = ''
         try:

--- a/clickhouse_mysql/writer/csvwriter.py
+++ b/clickhouse_mysql/writer/csvwriter.py
@@ -11,7 +11,7 @@ import uuid
 from clickhouse_mysql.writer.writer import Writer
 from clickhouse_mysql.event.event import Event
 
-import datetime
+from datetime import datetime
 
 from pymysqlreplication.row_event import WriteRowsEvent, UpdateRowsEvent, DeleteRowsEvent
 
@@ -271,17 +271,17 @@ class CSVWriter(Writer):
 
         if isinstance(event.pymysqlreplication_event, WriteRowsEvent):
             for row in event:
-                row['tb_upd'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+                row['tb_upd'] = event.ts.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
                 row['operation'] = 0
                 self.writer.writerow(self.convert(row))
         elif isinstance(event.pymysqlreplication_event, DeleteRowsEvent):
             for row in event:
-                row['tb_upd'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+                row['tb_upd'] = event.ts.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
                 row['operation'] = 2
                 self.writer.writerow(self.convert(row))
         elif isinstance(event.pymysqlreplication_event, UpdateRowsEvent):
             for row in event.pymysqlreplication_event.rows:
-                row['after_values']['tb_upd'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+                row['after_values']['tb_upd'] = event.ts.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
                 row['after_values']['operation'] = 1
                 self.writer.writerow(self.convert(row['after_values']))
 


### PR DESCRIPTION
We have seen events share values for tb_upd which is not normal. The problem is that if you use the pool events are grouped and we set them the tb_upd value at the end so they share the same ts. 

Here I've added a timestamp to the event so we can actually track when we receive the. 