### PR TITLE
Added newline parameter to support multiline fields

### DIFF
--- a/clickhouse_mysql/writer/csvwriter.py
+++ b/clickhouse_mysql/writer/csvwriter.py
@@ -253,7 +253,7 @@ class CSVWriter(Writer):
             if self.dst_table is None:
                 self.dst_table = event.table
 
-            self.writer = csv.DictWriter(self.file, fieldnames=self.fieldnames, quoting=csv.QUOTE_MINIMAL)
+            self.writer = csv.DictWriter(self.file, fieldnames=self.fieldnames, quoting=csv.QUOTE_MINIMAL, newline = '')
             if not self.header_written:
                 self.writer.writeheader()
 


### PR DESCRIPTION
Some fields can have multiple lines. If we want to support that kind of field we need to specify the newline parameter.