### PR TITLE
Removed unsuported parameter newline

### DIFF
--- a/clickhouse_mysql/writer/csvwriter.py
+++ b/clickhouse_mysql/writer/csvwriter.py
@@ -136,7 +136,7 @@ class CSVWriter(Writer):
             if self.dst_table is None:
                 self.dst_table = event.table
 
-            self.writer = csv.DictWriter(self.file, fieldnames=self.fieldnames, quoting=csv.QUOTE_MINIMAL)
+            self.writer = csv.DictWriter(self.file, fieldnames=self.fieldnames, quoting=csv.QUOTE_ALL)
             if not self.header_written:
                 self.writer.writeheader()
 
@@ -190,7 +190,7 @@ class CSVWriter(Writer):
             if self.dst_table is None:
                 self.dst_table = event.table
 
-            self.writer = csv.DictWriter(self.file, fieldnames=self.fieldnames, quoting=csv.QUOTE_MINIMAL)
+            self.writer = csv.DictWriter(self.file, fieldnames=self.fieldnames, quoting=csv.QUOTE_ALL)
             if not self.header_written:
                 self.writer.writeheader()
 
@@ -253,7 +253,7 @@ class CSVWriter(Writer):
             if self.dst_table is None:
                 self.dst_table = event.table
 
-            self.writer = csv.DictWriter(self.file, fieldnames=self.fieldnames, quoting=csv.QUOTE_MINIMAL, newline = '')
+            self.writer = csv.DictWriter(self.file, fieldnames=self.fieldnames, quoting=csv.csv.QUOTE_ALL)
             if not self.header_written:
                 self.writer.writeheader()
 


### PR DESCRIPTION
We need to add QUOTE_ALL to properly handle NULLs and empty strings.